### PR TITLE
Remove `extended_key_value_attributes`, which has been stabilized.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(extended_key_value_attributes)]
 #![doc=include_str!("../readme.md")]
 use std::ops::{Add,Div,Rem};
 


### PR DESCRIPTION
This is no longer necessary, and removing it allows this crate to be used with stable Rust.